### PR TITLE
Receive interrupt when inputed ScanDefaultString on new command

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -54,7 +54,7 @@ func Scan(message string, allowEmpty bool) (string, error) {
 			line, err = l.ReadlineWithDefault(ScanDefaultString)
 		}
 		if err == readline.ErrInterrupt {
-			if len(line) == 0 {
+			if len(line) <= len(ScanDefaultString) {
 				break
 			} else {
 				continue


### PR DESCRIPTION
like this

```
$ crowi new
Path> /user/sonatard/memo/2017/05/11/^C
canceled
```

```
$ crowi new
Path> /user/sonatard/memo/2017/05/11/hello^C
Path> /user/sonatard/memo/2017/05/11/^C
canceled
```